### PR TITLE
fix target_arch conditionals to match "riscv32" and "riscv64"

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -5,11 +5,11 @@ macro_rules! instruction {
         #[inline]
         pub fn $fnname() {
             match () {
-                #[cfg(target_arch = "riscv")]
+                #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
                 () => unsafe {
                     asm!($asm :::: "volatile");
                 },
-                #[cfg(not(target_arch = "riscv"))]
+                #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
                 () => {}
             }
         }

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -8,9 +8,9 @@ use register::mstatus;
 #[inline]
 pub unsafe fn disable() {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => mstatus::clear_mie(),
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => {}
     }
 }
@@ -23,9 +23,9 @@ pub unsafe fn disable() {
 #[inline]
 pub unsafe fn enable() {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => mstatus::set_mie(),
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => {}
     }
 }

--- a/src/register/mcause.rs
+++ b/src/register/mcause.rs
@@ -140,7 +140,7 @@ impl Mcause {
 #[inline]
 pub fn read() -> Mcause {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => {
             let r: usize;
             unsafe {
@@ -148,7 +148,7 @@ pub fn read() -> Mcause {
             }
             Mcause { bits: r }
         }
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }

--- a/src/register/mcycle.rs
+++ b/src/register/mcycle.rs
@@ -4,7 +4,7 @@
 #[inline]
 pub fn read() -> usize {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => {
             let r: usize;
             unsafe {
@@ -12,7 +12,7 @@ pub fn read() -> usize {
             }
             r
         }
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }

--- a/src/register/mcycleh.rs
+++ b/src/register/mcycleh.rs
@@ -4,7 +4,7 @@
 #[inline]
 pub fn read() -> usize {
     match () {
-        #[cfg(all(target_arch = "riscv", target_pointer_width = "32"))]
+        #[cfg(target_arch = "riscv32")]
         () => {
             let r: usize;
             unsafe {
@@ -12,7 +12,7 @@ pub fn read() -> usize {
             }
             r
         }
-        #[cfg(any(not(target_arch = "riscv"), not(target_pointer_width = "32")))]
+        #[cfg(not(target_arch = "riscv32"))]
         () => unimplemented!(),
     }
 }

--- a/src/register/mepc.rs
+++ b/src/register/mepc.rs
@@ -4,7 +4,7 @@
 #[inline]
 pub fn read() -> u32 {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => {
             let r: usize;
             unsafe {
@@ -12,7 +12,7 @@ pub fn read() -> u32 {
             }
             r as u32
         },
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }

--- a/src/register/mie.rs
+++ b/src/register/mie.rs
@@ -72,7 +72,7 @@ impl Mie {
 #[inline]
 pub fn read() -> Mie {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => {
             let r: usize;
             unsafe {
@@ -80,31 +80,31 @@ pub fn read() -> Mie {
             }
             Mie { bits: r }
         }
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }
 
 /// Sets the CSR
-#[cfg_attr(not(target_arch = "riscv"), allow(unused_variables))]
+#[cfg_attr(not(any(target_arch = "riscv32", target_arch = "riscv64")), allow(unused_variables))]
 #[inline]
 unsafe fn set(bits: usize) {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => asm!("csrrs x0, 0x304, $0" :: "r"(bits) :: "volatile"),
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }
 
 /// Clears the CSR
-#[cfg_attr(not(target_arch = "riscv"), allow(unused_variables))]
+#[cfg_attr(not(any(target_arch = "riscv32", target_arch = "riscv64")), allow(unused_variables))]
 #[inline]
 unsafe fn clear(bits: usize) {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => asm!("csrrc x0, 0x304, $0" :: "r"(bits) :: "volatile"),
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }

--- a/src/register/minstret.rs
+++ b/src/register/minstret.rs
@@ -4,7 +4,7 @@
 #[inline]
 pub fn read() -> usize {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => {
             let r: usize;
             unsafe {
@@ -12,7 +12,7 @@ pub fn read() -> usize {
             }
             r
         }
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }

--- a/src/register/minstreth.rs
+++ b/src/register/minstreth.rs
@@ -4,7 +4,7 @@
 #[inline]
 pub fn read() -> usize {
     match () {
-        #[cfg(all(target_arch = "riscv", target_pointer_width = "32"))]
+        #[cfg(target_arch = "riscv32")]
         () => {
             let r: usize;
             unsafe {
@@ -12,7 +12,7 @@ pub fn read() -> usize {
             }
             r
         },
-        #[cfg(any(not(target_arch = "riscv"), not(target_pointer_width = "32")))]
+        #[cfg(not(target_arch = "riscv32"))]
         () => unimplemented!(),
     }
 }

--- a/src/register/mip.rs
+++ b/src/register/mip.rs
@@ -72,7 +72,7 @@ impl Mip {
 #[inline]
 pub fn read() -> Mip {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => {
             let r: usize;
             unsafe {
@@ -80,7 +80,7 @@ pub fn read() -> Mip {
             }
             Mip { bits: r }
         }
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }

--- a/src/register/misa.rs
+++ b/src/register/misa.rs
@@ -49,7 +49,7 @@ impl Misa {
 #[inline]
 pub fn read() -> Option<Misa> {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => {
             let r: usize;
             unsafe {
@@ -63,7 +63,7 @@ pub fn read() -> Option<Misa> {
                 Some(Misa { bits: r })
             }
         },
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }

--- a/src/register/mstatus.rs
+++ b/src/register/mstatus.rs
@@ -83,7 +83,7 @@ impl Mstatus {
 #[inline]
 pub fn read() -> Mstatus {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => {
             let r: usize;
             unsafe {
@@ -91,31 +91,31 @@ pub fn read() -> Mstatus {
             }
             Mstatus { bits: r }
         }
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }
 
 /// Sets the CSR
-#[cfg_attr(not(target_arch = "riscv"), allow(unused_variables))]
+#[cfg_attr(not(any(target_arch = "riscv32", target_arch = "riscv64")), allow(unused_variables))]
 #[inline]
 unsafe fn set(bits: usize) {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => asm!("csrrs x0, 0x300, $0" :: "r"(bits) :: "volatile"),
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }
 
 /// Clears the CSR
-#[cfg_attr(not(target_arch = "riscv"), allow(unused_variables))]
+#[cfg_attr(not(any(target_arch = "riscv32", target_arch = "riscv64")), allow(unused_variables))]
 #[inline]
 unsafe fn clear(bits: usize) {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => asm!("csrrc x0, 0x300, $0" :: "r"(bits) :: "volatile"),
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }

--- a/src/register/mtvec.rs
+++ b/src/register/mtvec.rs
@@ -38,7 +38,7 @@ impl Mtvec {
 #[inline]
 pub fn read() -> Mtvec {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => {
             let r: usize;
             unsafe {
@@ -46,20 +46,20 @@ pub fn read() -> Mtvec {
             }
             Mtvec { bits: r }
         }
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }
 
 /// Writes the CSR
-#[cfg_attr(not(target_arch = "riscv"), allow(unused_variables))]
+#[cfg_attr(not(any(target_arch = "riscv32", target_arch = "riscv64")), allow(unused_variables))]
 #[inline]
 pub unsafe fn write(addr: usize, mode: TrapMode) {
     let bits = addr + mode as usize;
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => asm!("csrrw x0, 0x305, $0" :: "r"(bits) :: "volatile"),
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }

--- a/src/register/mvendorid.rs
+++ b/src/register/mvendorid.rs
@@ -22,7 +22,7 @@ impl Mvendorid {
 #[inline]
 pub fn read() -> Option<Mvendorid> {
     match () {
-        #[cfg(target_arch = "riscv")]
+        #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         () => {
             let r: usize;
             unsafe {
@@ -36,7 +36,7 @@ pub fn read() -> Option<Mvendorid> {
                 Some(Mvendorid { bits: r })
             }
         }
-        #[cfg(not(target_arch = "riscv"))]
+        #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
         () => unimplemented!(),
     }
 }


### PR DESCRIPTION
In the original riscv-rust fork the target arch was simply named
"riscv", but RISC-V support landed in Rust with "riscv32" as the arch
name instead.

Include "riscv64" optimistically for future-proofing.